### PR TITLE
Added annotation properties for ELAN generation.

### DIFF
--- a/owl/EASE.owl
+++ b/owl/EASE.owl
@@ -24,6 +24,34 @@
     
 
 
+    <!-- http://www.ease-crc.org/ont/EASE.owl#ELANName -->
+
+    <owl:AnnotationProperty rdf:about="http://www.ease-crc.org/ont/EASE.owl#ELANName">
+        <rdfs:subPropertyOf rdf:resource="http://www.ease-crc.org/ont/EASE.owl#nickname"/>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://www.ease-crc.org/ont/EASE.owl#ELANUsageGuideline -->
+
+    <owl:AnnotationProperty rdf:about="http://www.ease-crc.org/ont/EASE.owl#ELANUsageGuideline">
+        <rdfs:subPropertyOf rdf:resource="http://www.ease-crc.org/ont/EASE.owl#UsageGuideline"/>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://www.ease-crc.org/ont/EASE.owl#UsageGuideline -->
+
+    <owl:AnnotationProperty rdf:about="http://www.ease-crc.org/ont/EASE.owl#UsageGuideline"/>
+    
+
+
+    <!-- http://www.ease-crc.org/ont/EASE.owl#nickname -->
+
+    <owl:AnnotationProperty rdf:about="http://www.ease-crc.org/ont/EASE.owl#nickname"/>
+    
+
+
     <!-- http://www.ease-crc.org/ont/EASE.owl#symbol -->
 
     <owl:AnnotationProperty rdf:about="http://www.ease-crc.org/ont/EASE.owl#symbol">

--- a/owl/EASE.owl
+++ b/owl/EASE.owl
@@ -28,6 +28,7 @@
 
     <owl:AnnotationProperty rdf:about="http://www.ease-crc.org/ont/EASE.owl#ELANName">
         <rdfs:subPropertyOf rdf:resource="http://www.ease-crc.org/ont/EASE.owl#nickname"/>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">If present, used by the controlled vocabulary generation script to create a vocabulary entry. By default, the concept name itself is used for the vocabulary entry.</rdfs:comment>
     </owl:AnnotationProperty>
     
 
@@ -36,19 +37,26 @@
 
     <owl:AnnotationProperty rdf:about="http://www.ease-crc.org/ont/EASE.owl#ELANUsageGuideline">
         <rdfs:subPropertyOf rdf:resource="http://www.ease-crc.org/ont/EASE.owl#UsageGuideline"/>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Provides a short description, similar to a definition, of a controlled vocabulary entry for ELAN.</rdfs:comment>
     </owl:AnnotationProperty>
     
 
 
     <!-- http://www.ease-crc.org/ont/EASE.owl#UsageGuideline -->
 
-    <owl:AnnotationProperty rdf:about="http://www.ease-crc.org/ont/EASE.owl#UsageGuideline"/>
+    <owl:AnnotationProperty rdf:about="http://www.ease-crc.org/ont/EASE.owl#UsageGuideline">
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Provides a definition, or usage guideline, aimed at a particular community of the ontology's users. The community is identified by the subproperty of UsageGuideline.
+
+A style recommendation for usage guidelines is that they should be brief. In contrast to usual concept annotations that can, and should be detailed about the reasons behind modelling decisions, usage guidelines are simply meant to answer questions about when it is appropriate to use a concept, and they must be a practical, easy to query and understand resource.</rdfs:comment>
+    </owl:AnnotationProperty>
     
 
 
     <!-- http://www.ease-crc.org/ont/EASE.owl#nickname -->
 
-    <owl:AnnotationProperty rdf:about="http://www.ease-crc.org/ont/EASE.owl#nickname"/>
+    <owl:AnnotationProperty rdf:about="http://www.ease-crc.org/ont/EASE.owl#nickname">
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Similar to rdfs:label, but without GUI or reasoner impact in Protege; avoiding Protege problems is why this is not a label subproperty. Nicknames are used by particular software working with the ontology as a way to give community-specific names to concepts. Communities are identified by the subproperty of nickname.</rdfs:comment>
+    </owl:AnnotationProperty>
     
 
 


### PR DESCRIPTION
Adds two fairly generic annotation properties, and for each of them a more specific subproperty related to a particular user group of the ontology.

"nickname": similar to 'label', but without GUI or reasoner impact in Protege; avoiding Protege problems is why this is not a label subproperty. Nicknames are used by particular software working with the ontology as a way to give community-specific names.

"ELANName": subproperty of nickname. If present, used by the controlled vocabulary generation script to create a vocabulary entry. By default, the concept name itself is used for the vocabulary entry.

"UsageGuideline": annotation of a concept with an indication of how it is to be used in some context.

"ELANUsageGuideline": provides a short description, similar to a definition, of a controlled vocabulary entry for ELAN. Is a subproperty of UsageGuideline.
