### PR TITLE
Added body-related tasks.

### DIFF
--- a/owl/EASE-ACT.owl
+++ b/owl/EASE-ACT.owl
@@ -1,17 +1,17 @@
 <?xml version="1.0"?>
 <rdf:RDF xmlns="http://www.ease-crc.org/ont/EASE-ACT.owl#"
      xml:base="http://www.ease-crc.org/ont/EASE-ACT.owl"
-     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:ease="http://www.ease-crc.org/ont/EASE.owl#"
+     xmlns:ease-proc="http://www.ease-crc.org/ont/EASE-PROC.owl#"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:xml="http://www.w3.org/XML/1998/namespace"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
-     xmlns:ease="http://www.ease-crc.org/ont/EASE.owl#"
-     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-     xmlns:ease-proc="http://www.ease-crc.org/ont/EASE-PROC.owl#">
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
     <owl:Ontology rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl">
         <owl:imports rdf:resource="http://www.ease-crc.org/ont/EASE-PROC.owl"/>
-        <owl:imports rdf:resource="http://www.ease-crc.org/ont/EASE.owl"/>
         <owl:imports rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl"/>
+        <owl:imports rdf:resource="http://www.ease-crc.org/ont/EASE.owl"/>
     </owl:Ontology>
     
 
@@ -203,27 +203,16 @@
         <ease:ELANUsageGuideline>Superconcept for the Agent moving some (usually, but not always, grasped) object; use more specific labels where appropriate.</ease:ELANUsageGuideline>
         <rdfs:comment>Tasks where the goal is to move an object.
 
-Usually, an agent will use their prehensile effectors, ie. hands, for this purpose, so there is a lot of conceptual overlap between Actuating and ManipulationTasks.
+Usually, an agent will use their prehensile effectors, ie. hands, for this purpose, so there is a lot of conceptual overlap between Actuating and Manipulating.
 
-However, these categories are nonetheless distinguished in that there are more ways to actuate objects than simply manipulating them; for example, some tool like a catapult might be used to throw an object.
+However, these categories are nonetheless distinguished in that there are more ways to actuate objects than simply manipulating them; for example, some tool like a net or frying pan might be used to catch an object.
 
-Another way to look at the difference between Actuating and ManipulationTask is in what they &quot;profile&quot;, ie. focus on as important.
+Another way to look at the difference between Actuating and Manipulating is in what they &quot;profile&quot;, ie. focus on as important.
 
 For Actuating, it is the object&apos;s motion that is paramount.
 
-For ManipulationTask, it is the movement of the hand(s) and the change in functional relationships between the hand(s) and the manipulated object(s).</rdfs:comment>
+For Manipulating, it is the movement of the hand(s) and the change in functional relationships (such as kinematic control) between the hand(s) and the manipulated object(s).</rdfs:comment>
         <rdfs:comment>todo: think about use of tools. force events are generated between artifacts then. also not only the tool would be the &apos;salient artifact&apos; here.</rdfs:comment>
-    </owl:Class>
-    
-
-
-    <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#Approaching -->
-
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#Approaching">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#Locomotion"/>
-        <owl:disjointWith rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#Avoiding"/>
-        <ease:ELANName>move-body-walk-to</ease:ELANName>
-        <ease:ELANUsageGuideline>walk (to a location, or in a direction)</ease:ELANUsageGuideline>
     </owl:Class>
     
 
@@ -247,7 +236,7 @@ For ManipulationTask, it is the movement of the hand(s) and the change in functi
     <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#Avoiding -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#Avoiding">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PhysicalTask"/>
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#Navigating"/>
     </owl:Class>
     
 
@@ -369,16 +358,6 @@ Deduction is often explained as starting from the &quot;general&quot; (some prop
     
 
 
-    <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#Distancing -->
-
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#Distancing">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#Locomotion"/>
-        <ease:ELANName>move-body-walk-backaway</ease:ELANName>
-        <ease:ELANUsageGuideline>walk (away from a location, in a direction)</ease:ELANUsageGuideline>
-    </owl:Class>
-    
-
-
     <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#Dreaming -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#Dreaming">
@@ -405,7 +384,7 @@ Deduction is often explained as starting from the &quot;general&quot; (some prop
     <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#EndEffectorPositioning -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#EndEffectorPositioning">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#ManipulationTask"/>
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#Manipulating"/>
         <ease:ELANName>manipulation-hand-positioning</ease:ELANName>
         <ease:ELANUsageGuideline>Superconcept for the Agent moving their arm(s) to positioning their hand/end effector; use more specific labels where appropriate.</ease:ELANUsageGuideline>
     </owl:Class>
@@ -415,7 +394,7 @@ Deduction is often explained as starting from the &quot;general&quot; (some prop
     <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#Grasping -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#Grasping">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#ManipulationTask"/>
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#Manipulating"/>
         <owl:disjointWith rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#Releasing"/>
         <ease:ELANName>manipulation-grasp</ease:ELANName>
         <ease:ELANUsageGuideline>Agent grasps an object.</ease:ELANUsageGuideline>
@@ -423,30 +402,10 @@ Deduction is often explained as starting from the &quot;general&quot; (some prop
     
 
 
-    <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#HeadMovement -->
-
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#HeadMovement">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PhysicalTask"/>
-        <ease:ELANUsageGuideline>Superconcept for the Agent moving their head; use more specific labels where appropriate.</ease:ELANUsageGuideline>
-        <rdfs:comment>The Agent moves a part of their body carrying high-bandwidth sensors such as cameras. The movement of other body parts is not significant.</rdfs:comment>
-    </owl:Class>
-    
-
-
-    <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#HeadTurning -->
-
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#HeadTurning">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#HeadMovement"/>
-        <ease:ELANName>move-head-turn</ease:ELANName>
-        <ease:ELANUsageGuideline>Turn head (e.g. for visual search).</ease:ELANUsageGuideline>
-    </owl:Class>
-    
-
-
     <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#Holding -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#Holding">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#ManipulationTask"/>
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#Manipulating"/>
         <ease:ELANName>move-object-hold</ease:ELANName>
         <ease:ELANUsageGuideline>Have grasped an object with hand, and move it while held.</ease:ELANUsageGuideline>
     </owl:Class>
@@ -487,16 +446,6 @@ In this category we will place Actions for which such extra knowledge is require
     
 
 
-    <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#Leaning -->
-
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#Leaning">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PosturalMoving"/>
-        <ease:ELANName>move-body-lean</ease:ELANName>
-        <ease:ELANUsageGuideline>move, bending, with torso in a specific direction</ease:ELANUsageGuideline>
-    </owl:Class>
-    
-
-
     <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#Lifting -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#Lifting">
@@ -506,22 +455,6 @@ In this category we will place Actions for which such extra knowledge is require
         <ease:ELANName>move-object-lift</ease:ELANName>
         <ease:ELANUsageGuideline>Having grasped an object with their hand, the agent now lifts it from the supporting surface.</ease:ELANUsageGuideline>
         <rdfs:comment>todo: how to distinguish from e.g. &apos;pushing from the table&apos;</rdfs:comment>
-    </owl:Class>
-    
-
-
-    <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#Locomotion -->
-
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#Locomotion">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PhysicalTask"/>
-        <ease:ELANName>move-body-general</ease:ELANName>
-        <ease:ELANUsageGuideline>Superconcept for the Agent moving around; use more specific labels where appropriate.</ease:ELANUsageGuideline>
-        <rdfs:comment>Conceptually overlaps with Navigation, but distinguishable from it because of the profile, ie. the focus of the task.
-
-Navigation is about reaching some goal.
-
-Locomotion is concerned more with the actual motion.</rdfs:comment>
-        <rdfs:comment>The Agent repositions their body in the environment.</rdfs:comment>
     </owl:Class>
     
 
@@ -553,18 +486,9 @@ Locomotion is concerned more with the actual motion.</rdfs:comment>
     
 
 
-    <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#ManipulationAction -->
+    <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#Manipulating -->
 
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#ManipulationAction">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#ObservedAction"/>
-        <rdfs:comment>These are Actions in which the Agent exerts or prepares to exert some influence over some other participant Phyiscal Objects by way of its prehensile body parts (usually, hands).</rdfs:comment>
-    </owl:Class>
-    
-
-
-    <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#ManipulationTask -->
-
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#ManipulationTask">
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#Manipulating">
         <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PhysicalTask"/>
         <rdfs:subClassOf>
             <owl:Restriction>
@@ -574,16 +498,30 @@ Locomotion is concerned more with the actual motion.</rdfs:comment>
         </rdfs:subClassOf>
         <ease:ELANName>manipulation-general</ease:ELANName>
         <ease:ELANUsageGuideline>These are Actions in which the Agent exerts or prepares to exert some influence over some other participant Phyiscal Objects by way of its prehensile body parts (usually, hands).</ease:ELANUsageGuideline>
-        <rdfs:comment>Naming convention for other tasks suggests this should be &quot;Manipulating&quot;, however regular English usage strongly suggests &quot;manipulating&quot; means exerting psychological pressure on someone.</rdfs:comment>
-        <rdfs:comment>Tasks where the goal is to move the prehensile effectors, ie. hands, of an agent so as to achieve some functional relations towards some manipulated object.
+        <rdfs:comment>Tasks where the goal is to move the prehensile effectors, ie. hands, of an agent so as to achieve some spatial or functional relation with some manipulated object. 
 
-Note that manipulation tasks are usually performed with the intention of moving an object in some way, so there is a large conceptual overlap between ManipulationTask and Actuating.
+Spatial relations refer to positioning the hands in certain ways relative to the manipulated object, for example nearing or distancing them, or aligning them with some relevant axis.
+
+Functional relations here refer to interactions between the hands and manipulated object which constrain the possible behavior of the object. Examples of functional relations in manipulation are support and kinematic control.
+
+Note that manipulation tasks are usually performed with the intention of moving an object in some way, so there is a large conceptual overlap between Manipulating and Actuating.
 
 However these concepts are nonetheless distinguished in what they &quot;profile&quot;, ie. what they focus on as particularly important.
 
-Actuating profiles the movement of the object.
+Actuating profiles the movement of the object itself.
 
-ManipulationTask profiles the movement of the hands and the functional relations they establish with the manipulated object.</rdfs:comment>
+Manipulating profiles the movement of the hands and the functional relations, such as kinematic control, they establish with the manipulated object.
+
+Note: we employ Manipulating here in its literal, original sense, of using hands for some purpose, and not in the metaphorical sense of exerting psychological pressure on someone.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#ManipulationAction -->
+
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#ManipulationAction">
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#ObservedAction"/>
+        <rdfs:comment>These are Actions in which the Agent exerts or prepares to exert some influence over some other participant Phyiscal Objects by way of its prehensile body parts (usually, hands).</rdfs:comment>
     </owl:Class>
     
 
@@ -668,18 +606,10 @@ One could argue Mental actions are all Physical actions, because anything the Ag
     
 
 
-    <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#MovingAway -->
-
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#MovingAway">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#Locomotion"/>
-    </owl:Class>
-    
-
-
     <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#MovingTo -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#MovingTo">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#Locomotion"/>
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#Navigating"/>
     </owl:Class>
     
 
@@ -781,7 +711,7 @@ Our stance is to treat the goals of ObservedActions as convenient fictions, tole
     <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#PickingUp -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#PickingUp">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#ManipulationTask"/>
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#Manipulating"/>
         <ease:ELANName>move-object-pick-up</ease:ELANName>
         <ease:ELANUsageGuideline>Agent grasps an object and removes it from its previous location.</ease:ELANUsageGuideline>
     </owl:Class>
@@ -827,25 +757,6 @@ Our stance is to treat the goals of ObservedActions as convenient fictions, tole
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#PosturalAction">
         <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#ObservedAction"/>
         <rdfs:comment>The Agent changes the or assumes an overall configuration of their body but is otherwise not significantly affecting other objects nor moving a significant amount from its original location.
-
-Posture changes may take place as part of other actions, for example turning when walking.</rdfs:comment>
-    </owl:Class>
-    
-
-
-    <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#PosturalMoving -->
-
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#PosturalMoving">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PhysicalTask"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#classifies"/>
-                <owl:allValuesFrom rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PosturalAction"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <ease:ELANName>move-body-posture</ease:ELANName>
-        <ease:ELANUsageGuideline>Superconcept for motions where the Agent changes posture; use more specific labels where appropriate.</ease:ELANUsageGuideline>
-        <rdfs:comment>The Agent changes or takes an overall configuration of their body but is otherwise not significantly affecting other objects nor moving a significant amount from its original location.
 
 Posture changes may take place as part of other actions, for example turning when walking.</rdfs:comment>
     </owl:Class>
@@ -905,7 +816,7 @@ Posture changes may take place as part of other actions, for example turning whe
     <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#PuttingDown -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#PuttingDown">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#ManipulationTask"/>
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#Manipulating"/>
         <ease:ELANName>manipulation-put-down</ease:ELANName>
         <ease:ELANUsageGuideline>Agent releases their grasp on an object, but only after positioning it so that it is supported and won&apos;t fall.</ease:ELANUsageGuideline>
     </owl:Class>
@@ -995,7 +906,7 @@ Note, this classification has nothing to do with reasoning domain (e.g. SpatialR
     <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#Releasing -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#Releasing">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#ManipulationTask"/>
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#Manipulating"/>
         <ease:ELANName>manipulation-release</ease:ELANName>
         <ease:ELANUsageGuideline>Agent releases grasp on an object.</ease:ELANUsageGuideline>
     </owl:Class>
@@ -1050,16 +961,6 @@ Simulation does not commit itself to state accuracy: the initial state of the si
         <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#Actuating"/>
         <ease:ELANName>move-object-squeeze</ease:ELANName>
         <ease:ELANUsageGuideline>Exert compressive force on a (usually, but not always, grasped) object.</ease:ELANUsageGuideline>
-    </owl:Class>
-    
-
-
-    <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#Standing -->
-
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#Standing">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PosturalMoving"/>
-        <ease:ELANName>move-body-stand</ease:ELANName>
-        <ease:ELANUsageGuideline>stand (at a location)</ease:ELANUsageGuideline>
     </owl:Class>
     
 
@@ -1186,8 +1087,9 @@ Simulation does not commit itself to state accuracy: the initial state of the si
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#Throwing">
         <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#Actuating"/>
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#Manipulating"/>
         <ease:ELANName>move-object-throw</ease:ELANName>
-        <ease:ELANUsageGuideline>The agent imparts momentum to a held object then releases it.</ease:ELANUsageGuideline>
+        <ease:ELANUsageGuideline>Using its arm(s), an agent imparts momentum to a held object then releases it.</ease:ELANUsageGuideline>
     </owl:Class>
     
 
@@ -1205,91 +1107,9 @@ Simulation does not commit itself to state accuracy: the initial state of the si
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#Transporting">
         <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PhysicalTask"/>
     </owl:Class>
-    
-
-
-    <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#Turning -->
-
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#Turning">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PosturalMoving"/>
-        <ease:ELANName>move-body-turn</ease:ELANName>
-        <ease:ELANUsageGuideline>move own body, turn</ease:ELANUsageGuideline>
-    </owl:Class>
-    
-
-
-    <!-- http://www.ease-crc.org/ont/EASE-PROC.owl#Deformation -->
-
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-PROC.owl#Deformation"/>
-    
-
-
-    <!-- http://www.ease-crc.org/ont/EASE-PROC.owl#DirectedMotion -->
-
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-PROC.owl#DirectedMotion"/>
-    
-
-
-    <!-- http://www.ease-crc.org/ont/EASE-PROC.owl#EffectorContact -->
-
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-PROC.owl#EffectorContact"/>
-    
-
-
-    <!-- http://www.ease-crc.org/ont/EASE-PROC.owl#GraspingMotion -->
-
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-PROC.owl#GraspingMotion"/>
-    
-
-
-    <!-- http://www.ease-crc.org/ont/EASE-PROC.owl#LimbMotion -->
-
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-PROC.owl#LimbMotion"/>
-    
-
-
-    <!-- http://www.ease-crc.org/ont/EASE-PROC.owl#Locomotion -->
-
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-PROC.owl#Locomotion"/>
-    
-
-
-    <!-- http://www.ease-crc.org/ont/EASE-PROC.owl#ReleasingMotion -->
-
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-PROC.owl#ReleasingMotion"/>
-    
-
-
-    <!-- http://www.ease-crc.org/ont/EASE-PROC.owl#SupportingContact -->
-
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-PROC.owl#SupportingContact"/>
-    
-
-
-    <!-- http://www.ease-crc.org/ont/EASE.owl#ActionStatus -->
-
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE.owl#ActionStatus"/>
-    
-
-
-    <!-- http://www.ease-crc.org/ont/EASE.owl#ClosedState -->
-
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE.owl#ClosedState"/>
-    
-
-
-    <!-- http://www.ease-crc.org/ont/EASE.owl#OpenedState -->
-
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE.owl#OpenedState"/>
-    
-
-
-    <!-- http://www.ease-crc.org/ont/EASE.owl#PhysicalEffector -->
-
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE.owl#PhysicalEffector"/>
 </rdf:RDF>
 
 
 
-<!-- Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi -->
+<!-- Generated by the OWL API (version 4.2.8.20170104-2310) https://github.com/owlcs/owlapi -->
 

--- a/owl/EASE-ACT.owl
+++ b/owl/EASE-ACT.owl
@@ -1,17 +1,17 @@
 <?xml version="1.0"?>
 <rdf:RDF xmlns="http://www.ease-crc.org/ont/EASE-ACT.owl#"
      xml:base="http://www.ease-crc.org/ont/EASE-ACT.owl"
-     xmlns:ease="http://www.ease-crc.org/ont/EASE.owl#"
-     xmlns:ease-proc="http://www.ease-crc.org/ont/EASE-PROC.owl#"
-     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:xml="http://www.w3.org/XML/1998/namespace"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
-     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+     xmlns:ease="http://www.ease-crc.org/ont/EASE.owl#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:ease-proc="http://www.ease-crc.org/ont/EASE-PROC.owl#">
     <owl:Ontology rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl">
         <owl:imports rdf:resource="http://www.ease-crc.org/ont/EASE-PROC.owl"/>
-        <owl:imports rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl"/>
         <owl:imports rdf:resource="http://www.ease-crc.org/ont/EASE.owl"/>
+        <owl:imports rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl"/>
     </owl:Ontology>
     
 
@@ -195,11 +195,35 @@
     
 
 
+    <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#Actuating -->
+
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#Actuating">
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PhysicalTask"/>
+        <ease:ELANName>move-object</ease:ELANName>
+        <ease:ELANUsageGuideline>Superconcept for the Agent moving some (usually, but not always, grasped) object; use more specific labels where appropriate.</ease:ELANUsageGuideline>
+        <rdfs:comment>Tasks where the goal is to move an object.
+
+Usually, an agent will use their prehensile effectors, ie. hands, for this purpose, so there is a lot of conceptual overlap between Actuating and ManipulationTasks.
+
+However, these categories are nonetheless distinguished in that there are more ways to actuate objects than simply manipulating them; for example, some tool like a catapult might be used to throw an object.
+
+Another way to look at the difference between Actuating and ManipulationTask is in what they &quot;profile&quot;, ie. focus on as important.
+
+For Actuating, it is the object&apos;s motion that is paramount.
+
+For ManipulationTask, it is the movement of the hand(s) and the change in functional relationships between the hand(s) and the manipulated object(s).</rdfs:comment>
+        <rdfs:comment>todo: think about use of tools. force events are generated between artifacts then. also not only the tool would be the &apos;salient artifact&apos; here.</rdfs:comment>
+    </owl:Class>
+    
+
+
     <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#Approaching -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#Approaching">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PhysicalTask"/>
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#Locomotion"/>
         <owl:disjointWith rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#Avoiding"/>
+        <ease:ELANName>move-body-walk-to</ease:ELANName>
+        <ease:ELANUsageGuideline>walk (to a location, or in a direction)</ease:ELANUsageGuideline>
     </owl:Class>
     
 
@@ -231,8 +255,10 @@
     <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#Catching -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#Catching">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PhysicalTask"/>
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#Actuating"/>
         <owl:disjointWith rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PickingUp"/>
+        <ease:ELANName>move-object-catch</ease:ELANName>
+        <ease:ELANUsageGuideline>Agent intercepts and arrests the motion of an object.</ease:ELANUsageGuideline>
     </owl:Class>
     
 
@@ -240,10 +266,12 @@
     <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#Closing -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#Closing">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PhysicalTask"/>
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#Actuating"/>
         <owl:disjointWith rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#Lifting"/>
         <owl:disjointWith rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#Opening"/>
         <owl:disjointWith rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#Squeezing"/>
+        <ease:ELANName>move-object-close</ease:ELANName>
+        <ease:ELANUsageGuideline>Move an object so that it no longer exposes an interior surface.</ease:ELANUsageGuideline>
     </owl:Class>
     
 
@@ -341,6 +369,16 @@ Deduction is often explained as starting from the &quot;general&quot; (some prop
     
 
 
+    <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#Distancing -->
+
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#Distancing">
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#Locomotion"/>
+        <ease:ELANName>move-body-walk-backaway</ease:ELANName>
+        <ease:ELANUsageGuideline>walk (away from a location, in a direction)</ease:ELANUsageGuideline>
+    </owl:Class>
+    
+
+
     <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#Dreaming -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#Dreaming">
@@ -353,8 +391,10 @@ Deduction is often explained as starting from the &quot;general&quot; (some prop
     <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#Dropping -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#Dropping">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PhysicalTask"/>
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#Actuating"/>
         <owl:disjointWith rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#Placing"/>
+        <ease:ELANName>move-object-drop</ease:ELANName>
+        <ease:ELANUsageGuideline>Agent undoes whatever functional control they have on an object, but without imparting significant momentum to it, and allows the object to fall under the influence of gravity.</ease:ELANUsageGuideline>
         <rdfs:comment>The dropped object falls mainly under the influence of gravity. However, an agent may also drop something during navigation. The difference to &apos;Throwing&apos; is that there is no &apos;Limb motion&apos; which is a constitiuent of the action.
 
 &apos;Dropping&apos; is intentional. Dropping by accident may not has a phase to release the grasp. It could be that the grasp was not strong enough and the objects &quot;slips&quot; away.</rdfs:comment>
@@ -362,11 +402,43 @@ Deduction is often explained as starting from the &quot;general&quot; (some prop
     
 
 
+    <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#EndEffectorPositioning -->
+
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#EndEffectorPositioning">
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#ManipulationTask"/>
+        <ease:ELANName>manipulation-hand-positioning</ease:ELANName>
+        <ease:ELANUsageGuideline>Superconcept for the Agent moving their arm(s) to positioning their hand/end effector; use more specific labels where appropriate.</ease:ELANUsageGuideline>
+    </owl:Class>
+    
+
+
     <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#Grasping -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#Grasping">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PhysicalTask"/>
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#ManipulationTask"/>
         <owl:disjointWith rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#Releasing"/>
+        <ease:ELANName>manipulation-grasp</ease:ELANName>
+        <ease:ELANUsageGuideline>Agent grasps an object.</ease:ELANUsageGuideline>
+    </owl:Class>
+    
+
+
+    <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#HeadMovement -->
+
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#HeadMovement">
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PhysicalTask"/>
+        <ease:ELANUsageGuideline>Superconcept for the Agent moving their head; use more specific labels where appropriate.</ease:ELANUsageGuideline>
+        <rdfs:comment>The Agent moves a part of their body carrying high-bandwidth sensors such as cameras. The movement of other body parts is not significant.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#HeadTurning -->
+
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#HeadTurning">
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#HeadMovement"/>
+        <ease:ELANName>move-head-turn</ease:ELANName>
+        <ease:ELANUsageGuideline>Turn head (e.g. for visual search).</ease:ELANUsageGuideline>
     </owl:Class>
     
 
@@ -374,7 +446,9 @@ Deduction is often explained as starting from the &quot;general&quot; (some prop
     <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#Holding -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#Holding">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PhysicalTask"/>
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#ManipulationTask"/>
+        <ease:ELANName>move-object-hold</ease:ELANName>
+        <ease:ELANUsageGuideline>Have grasped an object with hand, and move it while held.</ease:ELANUsageGuideline>
     </owl:Class>
     
 
@@ -416,7 +490,9 @@ In this category we will place Actions for which such extra knowledge is require
     <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#Leaning -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#Leaning">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PhysicalTask"/>
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PosturalMoving"/>
+        <ease:ELANName>move-body-lean</ease:ELANName>
+        <ease:ELANUsageGuideline>move, bending, with torso in a specific direction</ease:ELANUsageGuideline>
     </owl:Class>
     
 
@@ -424,10 +500,28 @@ In this category we will place Actions for which such extra knowledge is require
     <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#Lifting -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#Lifting">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PhysicalTask"/>
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#Actuating"/>
         <owl:disjointWith rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#Opening"/>
         <owl:disjointWith rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#Pushing"/>
+        <ease:ELANName>move-object-lift</ease:ELANName>
+        <ease:ELANUsageGuideline>Having grasped an object with their hand, the agent now lifts it from the supporting surface.</ease:ELANUsageGuideline>
         <rdfs:comment>todo: how to distinguish from e.g. &apos;pushing from the table&apos;</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#Locomotion -->
+
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#Locomotion">
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PhysicalTask"/>
+        <ease:ELANName>move-body-general</ease:ELANName>
+        <ease:ELANUsageGuideline>Superconcept for the Agent moving around; use more specific labels where appropriate.</ease:ELANUsageGuideline>
+        <rdfs:comment>Conceptually overlaps with Navigation, but distinguishable from it because of the profile, ie. the focus of the task.
+
+Navigation is about reaching some goal.
+
+Locomotion is concerned more with the actual motion.</rdfs:comment>
+        <rdfs:comment>The Agent repositions their body in the environment.</rdfs:comment>
     </owl:Class>
     
 
@@ -452,7 +546,9 @@ In this category we will place Actions for which such extra knowledge is require
     <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#Lowering -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#Lowering">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PhysicalTask"/>
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#Actuating"/>
+        <ease:ELANName>move-object-lower</ease:ELANName>
+        <ease:ELANUsageGuideline>The agent lowers a, usually held in hand(s), object.</ease:ELANUsageGuideline>
     </owl:Class>
     
 
@@ -462,6 +558,32 @@ In this category we will place Actions for which such extra knowledge is require
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#ManipulationAction">
         <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#ObservedAction"/>
         <rdfs:comment>These are Actions in which the Agent exerts or prepares to exert some influence over some other participant Phyiscal Objects by way of its prehensile body parts (usually, hands).</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#ManipulationTask -->
+
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#ManipulationTask">
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PhysicalTask"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#classifies"/>
+                <owl:allValuesFrom rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#ManipulationAction"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <ease:ELANName>manipulation-general</ease:ELANName>
+        <ease:ELANUsageGuideline>These are Actions in which the Agent exerts or prepares to exert some influence over some other participant Phyiscal Objects by way of its prehensile body parts (usually, hands).</ease:ELANUsageGuideline>
+        <rdfs:comment>Naming convention for other tasks suggests this should be &quot;Manipulating&quot;, however regular English usage strongly suggests &quot;manipulating&quot; means exerting psychological pressure on someone.</rdfs:comment>
+        <rdfs:comment>Tasks where the goal is to move the prehensile effectors, ie. hands, of an agent so as to achieve some functional relations towards some manipulated object.
+
+Note that manipulation tasks are usually performed with the intention of moving an object in some way, so there is a large conceptual overlap between ManipulationTask and Actuating.
+
+However these concepts are nonetheless distinguished in what they &quot;profile&quot;, ie. what they focus on as particularly important.
+
+Actuating profiles the movement of the object.
+
+ManipulationTask profiles the movement of the hands and the functional relations they establish with the manipulated object.</rdfs:comment>
     </owl:Class>
     
 
@@ -549,7 +671,7 @@ One could argue Mental actions are all Physical actions, because anything the Ag
     <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#MovingAway -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#MovingAway">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PhysicalTask"/>
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#Locomotion"/>
     </owl:Class>
     
 
@@ -557,7 +679,7 @@ One could argue Mental actions are all Physical actions, because anything the Ag
     <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#MovingTo -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#MovingTo">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PhysicalTask"/>
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#Locomotion"/>
     </owl:Class>
     
 
@@ -606,8 +728,20 @@ Our stance is to treat the goals of ObservedActions as convenient fictions, tole
     <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#Opening -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#Opening">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PhysicalTask"/>
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#Actuating"/>
         <owl:disjointWith rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#Squeezing"/>
+        <ease:ELANName>move-object-open</ease:ELANName>
+        <ease:ELANUsageGuideline>Move an object so as to expose an interior surface.</ease:ELANUsageGuideline>
+    </owl:Class>
+    
+
+
+    <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#Orienting -->
+
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#Orienting">
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#Positioning"/>
+        <ease:ELANName>move-object-orient</ease:ELANName>
+        <ease:ELANUsageGuideline>Move object to re-orient it in place on an area, or while holding.</ease:ELANUsageGuideline>
     </owl:Class>
     
 
@@ -647,7 +781,9 @@ Our stance is to treat the goals of ObservedActions as convenient fictions, tole
     <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#PickingUp -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#PickingUp">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PhysicalTask"/>
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#ManipulationTask"/>
+        <ease:ELANName>move-object-pick-up</ease:ELANName>
+        <ease:ELANUsageGuideline>Agent grasps an object and removes it from its previous location.</ease:ELANUsageGuideline>
     </owl:Class>
     
 
@@ -656,6 +792,7 @@ Our stance is to treat the goals of ObservedActions as convenient fictions, tole
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#Placing">
         <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PhysicalTask"/>
+        <rdfs:comment>Distinguished from Positioning in that this task is more about placing an object at a functionally specified location (e.g., place the cup on the table) as opposed to positioning an object at a location defined by coordinates or a region of coordinates (position the cup at xyz).</rdfs:comment>
     </owl:Class>
     
 
@@ -678,7 +815,9 @@ Our stance is to treat the goals of ObservedActions as convenient fictions, tole
     <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#Positioning -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#Positioning">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PhysicalTask"/>
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#Actuating"/>
+        <ease:ELANName>move-object-positioning</ease:ELANName>
+        <ease:ELANUsageGuideline>Move an object so that it has a particular pose.</ease:ELANUsageGuideline>
     </owl:Class>
     
 
@@ -688,6 +827,25 @@ Our stance is to treat the goals of ObservedActions as convenient fictions, tole
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#PosturalAction">
         <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#ObservedAction"/>
         <rdfs:comment>The Agent changes the or assumes an overall configuration of their body but is otherwise not significantly affecting other objects nor moving a significant amount from its original location.
+
+Posture changes may take place as part of other actions, for example turning when walking.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#PosturalMoving -->
+
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#PosturalMoving">
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PhysicalTask"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#classifies"/>
+                <owl:allValuesFrom rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PosturalAction"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <ease:ELANName>move-body-posture</ease:ELANName>
+        <ease:ELANUsageGuideline>Superconcept for motions where the Agent changes posture; use more specific labels where appropriate.</ease:ELANUsageGuideline>
+        <rdfs:comment>The Agent changes or takes an overall configuration of their body but is otherwise not significantly affecting other objects nor moving a significant amount from its original location.
 
 Posture changes may take place as part of other actions, for example turning when walking.</rdfs:comment>
     </owl:Class>
@@ -715,7 +873,10 @@ Posture changes may take place as part of other actions, for example turning whe
     <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#Pushing -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#Pushing">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PhysicalTask"/>
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#Actuating"/>
+        <ease:ELANName>move-object-push</ease:ELANName>
+        <ease:ELANUsageGuideline>Superconcept for the Agent exerting force on an object to push it; use more specific labels where appropriate.</ease:ELANUsageGuideline>
+        <rdfs:comment>todo: define subclass &apos;PushingOver&apos;? Would we expect two distinct contacts with the same surface then?</rdfs:comment>
     </owl:Class>
     
 
@@ -725,6 +886,8 @@ Posture changes may take place as part of other actions, for example turning whe
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#PushingAway">
         <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#Pushing"/>
         <owl:disjointWith rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PushingDown"/>
+        <ease:ELANName>move-object-push-away</ease:ELANName>
+        <ease:ELANUsageGuideline>Agent exerts force on an object to move it away from themselves.</ease:ELANUsageGuideline>
     </owl:Class>
     
 
@@ -733,6 +896,8 @@ Posture changes may take place as part of other actions, for example turning whe
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#PushingDown">
         <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#Pushing"/>
+        <ease:ELANName>move-object-push-down</ease:ELANName>
+        <ease:ELANUsageGuideline>Exert force on an object to move it in some functionally meaningful direction, such as pushing down a button (even when the actual direction the button was pushed in was up).</ease:ELANUsageGuideline>
     </owl:Class>
     
 
@@ -740,7 +905,9 @@ Posture changes may take place as part of other actions, for example turning whe
     <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#PuttingDown -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#PuttingDown">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PhysicalTask"/>
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#ManipulationTask"/>
+        <ease:ELANName>manipulation-put-down</ease:ELANName>
+        <ease:ELANUsageGuideline>Agent releases their grasp on an object, but only after positioning it so that it is supported and won&apos;t fall.</ease:ELANUsageGuideline>
     </owl:Class>
     
 
@@ -793,8 +960,10 @@ Posture changes may take place as part of other actions, for example turning whe
     <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#Reaching -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#Reaching">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PhysicalTask"/>
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#EndEffectorPositioning"/>
         <owl:disjointWith rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#Retracting"/>
+        <ease:ELANName>move-hand+arm-reach</ease:ELANName>
+        <ease:ELANUsageGuideline>Reach arm out to prepare to grasp with hand.</ease:ELANUsageGuideline>
     </owl:Class>
     
 
@@ -826,7 +995,9 @@ Note, this classification has nothing to do with reasoning domain (e.g. SpatialR
     <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#Releasing -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#Releasing">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PhysicalTask"/>
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#ManipulationTask"/>
+        <ease:ELANName>manipulation-release</ease:ELANName>
+        <ease:ELANUsageGuideline>Agent releases grasp on an object.</ease:ELANUsageGuideline>
     </owl:Class>
     
 
@@ -843,7 +1014,9 @@ Note, this classification has nothing to do with reasoning domain (e.g. SpatialR
     <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#Retracting -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#Retracting">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PhysicalTask"/>
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#EndEffectorPositioning"/>
+        <ease:ELANName>move-hand+arm-retract</ease:ELANName>
+        <ease:ELANUsageGuideline>Draw in arm and hand toward body, and away from some object or location.</ease:ELANUsageGuideline>
     </owl:Class>
     
 
@@ -874,7 +1047,9 @@ Simulation does not commit itself to state accuracy: the initial state of the si
     <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#Squeezing -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#Squeezing">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PhysicalTask"/>
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#Actuating"/>
+        <ease:ELANName>move-object-squeeze</ease:ELANName>
+        <ease:ELANUsageGuideline>Exert compressive force on a (usually, but not always, grasped) object.</ease:ELANUsageGuideline>
     </owl:Class>
     
 
@@ -882,7 +1057,9 @@ Simulation does not commit itself to state accuracy: the initial state of the si
     <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#Standing -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#Standing">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PhysicalTask"/>
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PosturalMoving"/>
+        <ease:ELANName>move-body-stand</ease:ELANName>
+        <ease:ELANUsageGuideline>stand (at a location)</ease:ELANUsageGuideline>
     </owl:Class>
     
 
@@ -1008,7 +1185,9 @@ Simulation does not commit itself to state accuracy: the initial state of the si
     <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#Throwing -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#Throwing">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PhysicalTask"/>
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#Actuating"/>
+        <ease:ELANName>move-object-throw</ease:ELANName>
+        <ease:ELANUsageGuideline>The agent imparts momentum to a held object then releases it.</ease:ELANUsageGuideline>
     </owl:Class>
     
 
@@ -1032,7 +1211,9 @@ Simulation does not commit itself to state accuracy: the initial state of the si
     <!-- http://www.ease-crc.org/ont/EASE-ACT.owl#Turning -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl#Turning">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PhysicalTask"/>
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-ACT.owl#PosturalMoving"/>
+        <ease:ELANName>move-body-turn</ease:ELANName>
+        <ease:ELANUsageGuideline>move own body, turn</ease:ELANUsageGuideline>
     </owl:Class>
     
 
@@ -1110,5 +1291,5 @@ Simulation does not commit itself to state accuracy: the initial state of the si
 
 
 
-<!-- Generated by the OWL API (version 4.2.8.20170104-2310) https://github.com/owlcs/owlapi -->
+<!-- Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi -->
 

--- a/owl/EASE-PROC.owl
+++ b/owl/EASE-PROC.owl
@@ -97,6 +97,121 @@
     
 
 
+    <!-- http://www.ease-crc.org/ont/EASE-PROC.owl#Approaching -->
+
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-PROC.owl#Approaching">
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-PROC.owl#Locomotion"/>
+        <EASE:ELANName>move-body-walk-to</EASE:ELANName>
+        <EASE:ELANUsageGuideline>walk (to a location, or in a direction)</EASE:ELANUsageGuideline>
+    </owl:Class>
+    
+
+
+    <!-- http://www.ease-crc.org/ont/EASE-PROC.owl#BodyMovement -->
+
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-PROC.owl#BodyMovement">
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-PROC.owl#Motion"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#classifies"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#hasParticipant"/>
+                                <owl:someValuesFrom rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#PhysicalAgent"/>
+                            </owl:Restriction>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#hasParticipant"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#PhysicalObject"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#isPartOf"/>
+                                                <owl:someValuesFrom rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#PhysicalAgent"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <EASE:ELANName>move-body-general</EASE:ELANName>
+        <EASE:ELANUsageGuideline>The Agent moves its body in some way. Use more specific labels where appropriate.</EASE:ELANUsageGuideline>
+        <rdfs:comment>Motion described in terms of how parts of an Agent&apos;s body move.
+
+As such, this concept can be applied only to motions involving some PhysicalAgent, or body parts of a PhysicalAgent.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://www.ease-crc.org/ont/EASE-PROC.owl#HeadTurning -->
+
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-PROC.owl#HeadTurning">
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-PROC.owl#HeadMovement"/>
+        <EASE:ELANName>move-head-turn</EASE:ELANName>
+        <EASE:ELANUsageGuideline>Turn head (e.g. for visual search).</EASE:ELANUsageGuideline>
+    </owl:Class>
+    
+
+
+    <!-- http://www.ease-crc.org/ont/EASE-PROC.owl#Leaning -->
+
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-PROC.owl#Leaning">
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-PROC.owl#PosturalMoving"/>
+        <EASE:ELANName>move-body-lean</EASE:ELANName>
+        <EASE:ELANUsageGuideline>move, bending, with torso in a specific direction</EASE:ELANUsageGuideline>
+    </owl:Class>
+    
+
+
+    <!-- http://www.ease-crc.org/ont/EASE-PROC.owl#MovingAway -->
+
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-PROC.owl#MovingAway">
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-PROC.owl#Locomotion"/>
+        <EASE:ELANName>move-body-walk-backaway</EASE:ELANName>
+        <EASE:ELANUsageGuideline>walk (away from a location, in a direction)</EASE:ELANUsageGuideline>
+    </owl:Class>
+    
+
+
+    <!-- http://www.ease-crc.org/ont/EASE-PROC.owl#PosturalMoving -->
+
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-PROC.owl#PosturalMoving">
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-PROC.owl#BodyMovement"/>
+        <EASE:ELANName>move-body-posture</EASE:ELANName>
+        <EASE:ELANUsageGuideline>Superconcept for motions where the Agent changes posture; use more specific labels where appropriate.</EASE:ELANUsageGuideline>
+        <rdfs:comment>The Agent changes or takes an overall configuration of its body but is otherwise not significantly affecting other objects nor moving a significant amount from its original location.
+
+Posture changes may take place as part of other actions, for example turning when walking.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://www.ease-crc.org/ont/EASE-PROC.owl#Standing -->
+
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-PROC.owl#Standing">
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-PROC.owl#PosturalMoving"/>
+        <EASE:ELANName>move-body-stand</EASE:ELANName>
+        <EASE:ELANUsageGuideline>stand (at a location)</EASE:ELANUsageGuideline>
+    </owl:Class>
+    
+
+
+    <!-- http://www.ease-crc.org/ont/EASE-PROC.owl#Turning -->
+
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-PROC.owl#Turning">
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-PROC.owl#PosturalMoving"/>
+        <EASE:ELANName>move-body-turn</EASE:ELANName>
+        <EASE:ELANUsageGuideline>move own body, turn</EASE:ELANUsageGuideline>
+    </owl:Class>
+    
+
+
     <!-- http://www.ease-crc.org/ont/EASE-PROC.owl#ArtifactContact -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-PROC.owl#ArtifactContact">
@@ -327,7 +442,10 @@ An issue to highlight here is the maintenance of constitution. Fluids-- gases in
     <!-- http://www.ease-crc.org/ont/EASE-PROC.owl#HeadMovement -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-PROC.owl#HeadMovement">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-PROC.owl#Motion"/>
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-PROC.owl#BodyMovement"/>
+        <EASE:ELANName>move-head</EASE:ELANName>
+        <EASE:ELANUsageGuideline>Superconcept for the Agent moving their head; use more specific labels where appropriate.</EASE:ELANUsageGuideline>
+        <rdfs:comment>The Agent moves a part of their body carrying high-bandwidth sensors such as cameras. The movement of other body parts is not significant.</rdfs:comment>
         <rdfs:comment>todo: (Mihai:) This seems too specific, given the &quot;Directed&quot;/&quot;Undirected motion&quot; categories.</rdfs:comment>
     </owl:Class>
     
@@ -364,8 +482,17 @@ An issue to highlight here is the maintenance of constitution. Fluids-- gases in
     <!-- http://www.ease-crc.org/ont/EASE-PROC.owl#Locomotion -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-PROC.owl#Locomotion">
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-PROC.owl#BodyMovement"/>
         <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-PROC.owl#DirectedMotion"/>
         <owl:disjointWith rdf:resource="http://www.ease-crc.org/ont/EASE-PROC.owl#PrehensileMotion"/>
+        <EASE:ELANName>move-body-locomotion</EASE:ELANName>
+        <EASE:ELANUsageGuideline>Superconcept for the Agent moving around; use more specific labels where appropriate.</EASE:ELANUsageGuideline>
+        <rdfs:comment>Conceptually related to Navigation, but distinguishable from it because of the profile, ie. the focus of the task.
+
+Navigation is about reaching some goal.
+
+Locomotion is concerned more with the actual motion.</rdfs:comment>
+        <rdfs:comment>The Agent repositions their body in the environment.</rdfs:comment>
     </owl:Class>
     
 


### PR DESCRIPTION
The last and biggest patch to get the stuff from the ELAN branch to master.

The hierarchy underneath PhysicalTask is now less flat, as there are some intermediate level concepts such as PosturalMovement, Locomotion, ManipulationTask, and Actuating, which together absorb most of the tasks that were already present in master.

Not all tasks under master are absorbed, though arguably should be.

Some of the intermediate concepts seem very strongly related: Locomotion and Navigation; Actuating and ManipulationTask. I've tried to make clear in rdfs:comments what the differences between these are supposed to be. I think a difference does exist, but also significant gray areas.

An example is Holding. Historically, this was treated as an Actuating (which can be seen from the ELANName move-object-hold) however this gray case seems closer, imo, to ManipulationTask.

In general, the argument for why something is in Actuating is that the motion of the object is what matters most.

In general, the argument for why something is in ManipulationTask is that the motion of the hand matters most.

Note also that Locomotion has Approaching, Distancing, MovingAway, MovingTo. I did not make any relation between Approaching and MovingTo, and similarly none between Distancing and MovingAway, because I'm not sure what MovingX was supposed to cover. These concepts came from the master branch already, and so did Approaching. Distancing comes from the ELAN branch as a natural counterpart of Approaching.