### PR TITLE
Added script to invoke hermit and produce warnings when some concept …

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -23,3 +23,16 @@ Dependencies:
 * ROS
 * rosprolog
 
+**Testing consistency**
+
+Run the hermit.py script to verify an OWL file with the HermiT reasoner. Verification here means checking whether some concepts are subsumed by owl:Nothing, ie. they are unsatisfiable.
+
+Syntax to run the script is:
+
+./hermit_test.py [options] inputfile
+
+where inputfile is a path to an OWL file. The following options are available:
+* -r, --reasoner: path to HermiT.jar, the executable for the HermiT reasoner. If not provided, it is assumed the jar is in the same folder as where the script is called from
+* -o, --output: path to a file where to store the results of the HermiT reasoner. If not provided, results are not stored
+
+Classification and subsumption reasoning will be performed on the input owl file. In case of non-satisfiable concepts, messages will be produced on stdout (ie. the console) by the script. A successful run of the script, that is, if no errors happen and no non-satisfiable concepts are found, produces no console output.

--- a/scripts/hermit_test.py
+++ b/scripts/hermit_test.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import os
 import sys
 from optparse import OptionParser

--- a/scripts/hermit_test.py
+++ b/scripts/hermit_test.py
@@ -1,0 +1,64 @@
+import os
+import sys
+from optparse import OptionParser
+
+import subprocess
+import re
+
+usage = "usage: %prog [options] inputfile"
+parser = OptionParser(usage)
+parser.add_option("-o", "--output", dest="output", default=None,
+                  help="output FILE", metavar="OUTPUT")
+parser.add_option("-r", "--reasoner", dest="reasoner", metavar="REASONER", default="./HermiT.jar",
+                  help="path to REASONER (assumed to be HermiT.jar)")
+
+(options, args) = parser.parse_args()
+
+if 1 != len(args):
+    parser.error("incorrect number of arguments")
+
+proc = subprocess.Popen(["java", "-Xmx1024M", "-jar", options.reasoner, "--classify", "--classifyOPs", args[0]], stdout=subprocess.PIPE)
+results = proc.stdout.read().decode()
+
+if options.output:
+    with open(options.output, "w") as outfile:
+        outfile.write(results)
+
+subsumptions = results.splitlines()
+
+owlNothing = re.compile("owl\\#Nothing[\\>]?")
+owlBottomObjectProperty = re.compile("owl\\#bottomObjectProperty[\\>]?")
+
+equivalentClasses = re.compile('^EquivalentClasses\\( (?P<A>[\\w\\#\\<\\>:/\\-\\.]*) (?P<B>[\\w\\#\\<\\>:/\\-\\.]*) \\)$')
+equivalentObjectProperties = re.compile('^EquivalentObjectProperties\\( (?P<A>[\\w\\#\\<\\>:/\\-\\.]*) (?P<B>[\\w\\#\\<\\>:/\\-\\.]*) \\)$')
+subClassOf = re.compile('^SubClassOf\\( (?P<sub>[\\w\\#\\<\\>:/\\-\\.]*) (?P<sup>[\\w\\#\\<\\>:/\\-\\.]*) \\)$')
+subObjectPropertyOf = re.compile('^SubObjectPropertyOf\\( (?P<sub>[\\w\\#\\<\\>:/\\-\\.]*) (?P<sup>[\\w\\#\\<\\>:/\\-\\.]*) \\)$')
+
+for s in subsumptions:
+    isEquivalentClass = equivalentClasses.match(s)
+    isEquivalentProperty = equivalentObjectProperties.match(s)
+    isSubclass = subClassOf.match(s)
+    isSubproperty = subObjectPropertyOf.match(s)
+    if isEquivalentClass:
+        AisNothing = owlNothing.search(isEquivalentClass.group('A'))
+        BisNothing = owlNothing.search(isEquivalentClass.group('B'))
+        if AisNothing:
+            print("WARNING: %s is subclass of Nothing" % isEquivalentClass.group('B'))
+        if BisNothing:
+            print("WARNING: %s is subclass of Nothing" % isEquivalentClass.group('A'))
+    if isEquivalentProperty:
+        AisNothing = owlBottomObjectProperty.search(isEquivalentProperty.group('A'))
+        BisNothing = owlBottomObjectProperty.search(isEquivalentProperty.group('B'))
+        if AisNothing:
+            print("WARNING: %s is subproperty of bottomObjectProperty" % isEquivalentProperty.group('B'))
+        if BisNothing:
+            print("WARNING: %s is subproperty of bottomObjectProperty" % isEquivalentProperty.group('A'))
+    if isSubclass:
+        SupisNothing = owlNothing.search(isSubclass.group('sup'))
+        if SupisNothing:
+            print("WARNING: %s is subclass of Nothing" % isSubclass.group('sub'))
+    if isSubproperty:
+        SupisNothing = owlBottomObjectProperty.search(isSubproperty.group('sup'))
+        if SupisNothing:
+            print("WARNING: %s is subproperty of bottomObjectProperty" % isSubproperty.group('sub'))
+

--- a/scripts/hermit_test.py
+++ b/scripts/hermit_test.py
@@ -36,12 +36,20 @@ if options.output:
 
 subsumptions = results.splitlines()
 
-owlNothing = re.compile("owl\\#Nothing[\\>]?")
-owlBottomObjectProperty = re.compile("owl\\#bottomObjectProperty[\\>]?")
+#### Define parsing patterns for HermiT output
+## Parsing proceeds by first recognizing axioms in OWL functional notation, and extracting the participating concept/relation names from these axioms.
+## Names of concepts/relations are allowed to include alphanumeric characters, _, -, /, #, :, ., and the < and > characters
 
+owlNothing = re.compile("owl\\#Nothing[\\>]?") ## Recognize a mention of owl:Nothing; example: owl#Nothing
+owlBottomObjectProperty = re.compile("owl\\#bottomObjectProperty[\\>]?") ## Recognize a mention of owl:bottomObjectProperty; example: owl#bottomObjectProperty
+
+## Parse an EquivalentClasses axiom; example: EquivalentClasses( https://example.org/example.owl#Thing1 owl#Nothing )
 equivalentClasses = re.compile('^EquivalentClasses\\( (?P<A>[\\w\\#\\<\\>:/\\-\\.]*) (?P<B>[\\w\\#\\<\\>:/\\-\\.]*) \\)$')
+## Parse an EquivalentObjectProperties axiom; example: EquivalentObjectProperties( https://example.org/example.owl#relation1 owl#bottomObjectProperty )
 equivalentObjectProperties = re.compile('^EquivalentObjectProperties\\( (?P<A>[\\w\\#\\<\\>:/\\-\\.]*) (?P<B>[\\w\\#\\<\\>:/\\-\\.]*) \\)$')
+## Parse a SubclassOf axiom; example: SubClassOf( https://example.org/example.owl#Thing1 owl#Nothing )
 subClassOf = re.compile('^SubClassOf\\( (?P<sub>[\\w\\#\\<\\>:/\\-\\.]*) (?P<sup>[\\w\\#\\<\\>:/\\-\\.]*) \\)$')
+## Parse a SubObjectProperty axiom; example: SubObjectPropertyOf( https://example.org/example.owl#relation1 owl#bottomObjectProperty )
 subObjectPropertyOf = re.compile('^SubObjectPropertyOf\\( (?P<sub>[\\w\\#\\<\\>:/\\-\\.]*) (?P<sup>[\\w\\#\\<\\>:/\\-\\.]*) \\)$')
 
 for s in subsumptions:


### PR DESCRIPTION
…is subsumed by Nothing.

To call, use something like

python3 hermit_test.py --reasoner /usr/local/HermiT/HermiT.jar EASE-uglyfied.owl

Outputs to stdout a list of items such as

WARNING: <http://example.org/owl/musteronto#Example> is subclass of Nothing

If everything is ok there should be no stdout output.

If the reasoner can't start at all, e.g. because the ontology is undecidable, then an Exception message is printed to that stdout output.

These texts could be piped into a file or wherever some other continuous integration script can make use of them.

