### PR TITLE
Imports

### DIFF
--- a/owl/EASE-ACT.owl
+++ b/owl/EASE-ACT.owl
@@ -9,9 +9,10 @@
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
     <owl:Ontology rdf:about="http://www.ease-crc.org/ont/EASE-ACT.owl">
-        <owl:imports rdf:resource="http://www.ease-crc.org/ont/EASE-PROC.owl"/>
+        <owl:imports rdf:resource="package://ease_ontology/owl/EASE-PROC.owl"/>
+        <owl:imports rdf:resource="package://ease_ontology/owl/EASE-STATE.owl"/>
         <owl:imports rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl"/>
-        <owl:imports rdf:resource="http://www.ease-crc.org/ont/EASE.owl"/>
+        <owl:imports rdf:resource="package://ease_ontology/owl/EASE.owl"/>
     </owl:Ontology>
     
 

--- a/owl/EASE-PROC.owl
+++ b/owl/EASE-PROC.owl
@@ -10,7 +10,7 @@
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:EASE="http://www.ease-crc.org/ont/EASE.owl#">
     <owl:Ontology rdf:about="http://www.ease-crc.org/ont/EASE-PROC.owl">
-        <owl:imports rdf:resource="http://www.ease-crc.org/ont/EASE.owl"/>
+        <owl:imports rdf:resource="package://ease_ontology/owl/EASE.owl"/>
     </owl:Ontology>
     
 

--- a/owl/EASE-WF.owl
+++ b/owl/EASE-WF.owl
@@ -11,7 +11,7 @@
      xmlns:EASE="http://www.ease-crc.org/ont/EASE.owl#"
      xmlns:ease_wf="http://www.ease-crc.org/ont/EASE-WF.owl#">
     <owl:Ontology rdf:about="http://www.ease-crc.org/ont/EASE-WF.owl">
-        <owl:imports rdf:resource="http://www.ease-crc.org/ont/EASE.owl"/>
+        <owl:imports rdf:resource="package://ease_ontology/owl/EASE.owl"/>
         <owl:imports rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl"/>
         <owl:imports rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/IOLite.owl"/>
     </owl:Ontology>


### PR DESCRIPTION
I had to switch back to ROS-style package URLS for now. I think the reason is *ease-crc* delivering a weird HTML page instead of a plain 404 code and protege seems to think sometimes this HTML page is the ontology.