### PR TITLE
Refactor

### DIFF
--- a/owl/EASE-OBJ.owl
+++ b/owl/EASE-OBJ.owl
@@ -854,6 +854,14 @@
     
 
 
+    <!-- http://www.ease-crc.org/ont/EASE-OBJ.owl#Accessor -->
+
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-OBJ.owl#Accessor">
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-OBJ.owl#Instrument"/>
+    </owl:Class>
+    
+
+
     <!-- http://www.ease-crc.org/ont/EASE-OBJ.owl#Affordance -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-OBJ.owl#Affordance">
@@ -949,7 +957,7 @@
     <!-- http://www.ease-crc.org/ont/EASE-OBJ.owl#Barrier -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-OBJ.owl#Barrier">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-OBJ.owl#Instrument"/>
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-OBJ.owl#Restrictor"/>
         <rdfs:comment>An object used to prevent others from entering or leaving a restricted space or group.</rdfs:comment>
     </owl:Class>
     
@@ -1201,7 +1209,7 @@
     <!-- http://www.ease-crc.org/ont/EASE-OBJ.owl#Container -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-OBJ.owl#Container">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-OBJ.owl#Instrument"/>
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-OBJ.owl#Restrictor"/>
         <rdfs:comment>An object used to contain others.</rdfs:comment>
     </owl:Class>
     
@@ -1895,6 +1903,14 @@
     
 
 
+    <!-- http://www.ease-crc.org/ont/EASE-OBJ.owl#Item -->
+
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-OBJ.owl#Item">
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-OBJ.owl#Patient"/>
+    </owl:Class>
+    
+
+
     <!-- http://www.ease-crc.org/ont/EASE-OBJ.owl#KineticFrictionAttribute -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-OBJ.owl#KineticFrictionAttribute">
@@ -2191,6 +2207,14 @@
     
 
 
+    <!-- http://www.ease-crc.org/ont/EASE-OBJ.owl#Protector -->
+
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-OBJ.owl#Protector">
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-OBJ.owl#Restrictor"/>
+    </owl:Class>
+    
+
+
     <!-- http://www.ease-crc.org/ont/EASE-OBJ.owl#Purification -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-OBJ.owl#Purification">
@@ -2256,6 +2280,14 @@
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-OBJ.owl#RestrictedObject">
         <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-OBJ.owl#BlockedObject"/>
         <rdfs:comment>An object with restrictions to access something.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://www.ease-crc.org/ont/EASE-OBJ.owl#Restrictor -->
+
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-OBJ.owl#Restrictor">
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-OBJ.owl#Instrument"/>
     </owl:Class>
     
 
@@ -2490,7 +2522,7 @@
     <!-- http://www.ease-crc.org/ont/EASE-OBJ.owl#Supporter -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-OBJ.owl#Supporter">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-OBJ.owl#ConnectedObject"/>
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-OBJ.owl#Restrictor"/>
         <rdfs:comment>An object used to support others.</rdfs:comment>
     </owl:Class>
     

--- a/owl/EASE-PROC.owl
+++ b/owl/EASE-PROC.owl
@@ -50,18 +50,6 @@
     
 
 
-    <!-- http://www.ease-crc.org/ont/EASE.owl#hasCreated -->
-
-    <owl:ObjectProperty rdf:about="http://www.ease-crc.org/ont/EASE.owl#hasCreated"/>
-    
-
-
-    <!-- http://www.ease-crc.org/ont/EASE.owl#hasDestroyed -->
-
-    <owl:ObjectProperty rdf:about="http://www.ease-crc.org/ont/EASE.owl#hasDestroyed"/>
-    
-
-
     <!-- http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#classifies -->
 
     <owl:ObjectProperty rdf:about="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#classifies"/>
@@ -107,6 +95,32 @@
     
 
 
+    <!-- http://www.ease-crc.org/ont/EASE-PROC.owl#ArtifactContact -->
+
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-PROC.owl#ArtifactContact">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://www.ease-crc.org/ont/EASE-PROC.owl#Contact"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#hasParticipant"/>
+                        <owl:someValuesFrom rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#PhysicalArtifact"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-PROC.owl#Contact"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#hasParticipant"/>
+                <owl:someValuesFrom rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#PhysicalArtifact"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label>Artifact contact</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://www.ease-crc.org/ont/EASE-PROC.owl#BodyMovement -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-PROC.owl#BodyMovement">
@@ -145,95 +159,6 @@
         <rdfs:comment>Motion described in terms of how parts of an Agent&apos;s body move.
 
 As such, this concept can be applied only to motions involving some PhysicalAgent, or body parts of a PhysicalAgent.</rdfs:comment>
-    </owl:Class>
-    
-
-
-    <!-- http://www.ease-crc.org/ont/EASE-PROC.owl#HeadTurning -->
-
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-PROC.owl#HeadTurning">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-PROC.owl#HeadMovement"/>
-        <EASE:ELANName>move-head-turn</EASE:ELANName>
-        <EASE:ELANUsageGuideline>Turn head (e.g. for visual search).</EASE:ELANUsageGuideline>
-    </owl:Class>
-    
-
-
-    <!-- http://www.ease-crc.org/ont/EASE-PROC.owl#Leaning -->
-
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-PROC.owl#Leaning">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-PROC.owl#PosturalMoving"/>
-        <EASE:ELANName>move-body-lean</EASE:ELANName>
-        <EASE:ELANUsageGuideline>move, bending, with torso in a specific direction</EASE:ELANUsageGuideline>
-    </owl:Class>
-    
-
-
-    <!-- http://www.ease-crc.org/ont/EASE-PROC.owl#MovingAway -->
-
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-PROC.owl#MovingAway">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-PROC.owl#Locomotion"/>
-        <EASE:ELANName>move-body-walk-backaway</EASE:ELANName>
-        <EASE:ELANUsageGuideline>walk (away from a location, in a direction)</EASE:ELANUsageGuideline>
-    </owl:Class>
-    
-
-
-    <!-- http://www.ease-crc.org/ont/EASE-PROC.owl#PosturalMoving -->
-
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-PROC.owl#PosturalMoving">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-PROC.owl#BodyMovement"/>
-        <EASE:ELANName>move-body-posture</EASE:ELANName>
-        <EASE:ELANUsageGuideline>Superconcept for motions where the Agent changes posture; use more specific labels where appropriate.</EASE:ELANUsageGuideline>
-        <rdfs:comment>The Agent changes or takes an overall configuration of its body but is otherwise not significantly affecting other objects nor moving a significant amount from its original location.
-
-Posture changes may take place as part of other actions, for example turning when walking.</rdfs:comment>
-    </owl:Class>
-    
-
-
-    <!-- http://www.ease-crc.org/ont/EASE-PROC.owl#Standing -->
-
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-PROC.owl#Standing">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-PROC.owl#PosturalMoving"/>
-        <EASE:ELANName>move-body-stand</EASE:ELANName>
-        <EASE:ELANUsageGuideline>stand (at a location)</EASE:ELANUsageGuideline>
-    </owl:Class>
-    
-
-
-    <!-- http://www.ease-crc.org/ont/EASE-PROC.owl#Turning -->
-
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-PROC.owl#Turning">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-PROC.owl#PosturalMoving"/>
-        <EASE:ELANName>move-body-turn</EASE:ELANName>
-        <EASE:ELANUsageGuideline>move own body, turn</EASE:ELANUsageGuideline>
-    </owl:Class>
-    
-
-
-    <!-- http://www.ease-crc.org/ont/EASE-PROC.owl#ArtifactContact -->
-
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-PROC.owl#ArtifactContact">
-        <owl:equivalentClass>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://www.ease-crc.org/ont/EASE-PROC.owl#Contact"/>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#hasParticipant"/>
-                        <owl:someValuesFrom rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#PhysicalArtifact"/>
-                    </owl:Restriction>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:equivalentClass>
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-PROC.owl#Contact"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#hasParticipant"/>
-                <owl:someValuesFrom rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#PhysicalArtifact"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:label>Artifact contact</rdfs:label>
     </owl:Class>
     
 
@@ -281,12 +206,6 @@ In some sense any process that results in entities being created or destroyed mi
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-PROC.owl#Creation">
         <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-PROC.owl#ProcessType"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://www.ease-crc.org/ont/EASE.owl#hasCreated"/>
-                <owl:someValuesFrom rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#PhysicalObject"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
         <rdfs:comment>A process by which an Entity is created in the physical world.
 
 Note, most of the physical Entities we will be considering here are in fact arrangements of many other, smaller physical Entities. Therefore another way to look at this is, a &apos;Physical creation&apos; is the process by which a set of physical Entities is arranged in a certain way, and the arrangement is then itself considered a physical Entity.</rdfs:comment>
@@ -320,12 +239,6 @@ A soft slab of clay deforming under its own weight on Earth would still count as
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-PROC.owl#Destruction">
         <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-PROC.owl#ProcessType"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://www.ease-crc.org/ont/EASE.owl#hasDestroyed"/>
-                <owl:someValuesFrom rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#PhysicalObject"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
         <rdfs:comment>A process by which a physical Entity is destroyed.
 
 Note, most of the physical Entities we are concerned with are actually arrangements of many smaller physical Entities, so another way to look at this is that a &apos;Physical destruction&apos; is a process by which an arrangement of physical Entities, which was previously itself considered a physical Entity, is changed to such an extent that it is no longer recognized as continuing to exist.</rdfs:comment>
@@ -451,6 +364,16 @@ An issue to highlight here is the maintenance of constitution. Fluids-- gases in
     
 
 
+    <!-- http://www.ease-crc.org/ont/EASE-PROC.owl#HeadTurning -->
+
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-PROC.owl#HeadTurning">
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-PROC.owl#HeadMovement"/>
+        <EASE:ELANName>move-head-turn</EASE:ELANName>
+        <EASE:ELANUsageGuideline>Turn head (e.g. for visual search).</EASE:ELANUsageGuideline>
+    </owl:Class>
+    
+
+
     <!-- http://www.ease-crc.org/ont/EASE-PROC.owl#IntermediateGrasp -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-PROC.owl#IntermediateGrasp">
@@ -458,6 +381,16 @@ An issue to highlight here is the maintenance of constitution. Fluids-- gases in
         <owl:disjointWith rdf:resource="http://www.ease-crc.org/ont/EASE-PROC.owl#PowerGrasp"/>
         <owl:disjointWith rdf:resource="http://www.ease-crc.org/ont/EASE-PROC.owl#PrecisionGrasp"/>
         <rdfs:label>Intermediate grasp</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://www.ease-crc.org/ont/EASE-PROC.owl#Leaning -->
+
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-PROC.owl#Leaning">
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-PROC.owl#PosturalMoving"/>
+        <EASE:ELANName>move-body-lean</EASE:ELANName>
+        <EASE:ELANUsageGuideline>move, bending, with torso in a specific direction</EASE:ELANUsageGuideline>
     </owl:Class>
     
 
@@ -507,6 +440,16 @@ Locomotion is concerned more with the actual motion.</rdfs:comment>
     
 
 
+    <!-- http://www.ease-crc.org/ont/EASE-PROC.owl#MovingAway -->
+
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-PROC.owl#MovingAway">
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-PROC.owl#Locomotion"/>
+        <EASE:ELANName>move-body-walk-backaway</EASE:ELANName>
+        <EASE:ELANUsageGuideline>walk (away from a location, in a direction)</EASE:ELANUsageGuideline>
+    </owl:Class>
+    
+
+
     <!-- http://www.ease-crc.org/ont/EASE-PROC.owl#PhaseTransition -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-PROC.owl#PhaseTransition">
@@ -516,6 +459,19 @@ Locomotion is concerned more with the actual motion.</rdfs:comment>
         <rdfs:seeAlso>The phase transition concept has also been more or less metaphorically applied in other contexts. An example from physics is the &quot;jamming transition&quot;, and sometimes &quot;phase transitions&quot; are spoken of when describing problem spaces such as 3SAT.
 
 In all these cases, the metaphor points to the existence of several regions of qualitatively different behavior (unimpeded passage of solid grains vs deadlock in a corridor; problem instances where the answer NO is trivial to prove vs. problem instances where the answer YES is trivial to prove), separated fairly sharply when some quantity reaches a threshold.</rdfs:seeAlso>
+    </owl:Class>
+    
+
+
+    <!-- http://www.ease-crc.org/ont/EASE-PROC.owl#PosturalMoving -->
+
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-PROC.owl#PosturalMoving">
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-PROC.owl#BodyMovement"/>
+        <EASE:ELANName>move-body-posture</EASE:ELANName>
+        <EASE:ELANUsageGuideline>Superconcept for motions where the Agent changes posture; use more specific labels where appropriate.</EASE:ELANUsageGuideline>
+        <rdfs:comment>The Agent changes or takes an overall configuration of its body but is otherwise not significantly affecting other objects nor moving a significant amount from its original location.
+
+Posture changes may take place as part of other actions, for example turning when walking.</rdfs:comment>
     </owl:Class>
     
 
@@ -630,6 +586,16 @@ In all these cases, the metaphor points to the existence of several regions of q
     
 
 
+    <!-- http://www.ease-crc.org/ont/EASE-PROC.owl#Standing -->
+
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-PROC.owl#Standing">
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-PROC.owl#PosturalMoving"/>
+        <EASE:ELANName>move-body-stand</EASE:ELANName>
+        <EASE:ELANUsageGuideline>stand (at a location)</EASE:ELANUsageGuideline>
+    </owl:Class>
+    
+
+
     <!-- http://www.ease-crc.org/ont/EASE-PROC.owl#SupportingContact -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-PROC.owl#SupportingContact">
@@ -644,6 +610,16 @@ In all these cases, the metaphor points to the existence of several regions of q
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-PROC.owl#Swimming">
         <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-PROC.owl#Locomotion"/>
         <owl:disjointWith rdf:resource="http://www.ease-crc.org/ont/EASE-PROC.owl#Walking"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.ease-crc.org/ont/EASE-PROC.owl#Turning -->
+
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-PROC.owl#Turning">
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-PROC.owl#PosturalMoving"/>
+        <EASE:ELANName>move-body-turn</EASE:ELANName>
+        <EASE:ELANUsageGuideline>move own body, turn</EASE:ELANUsageGuideline>
     </owl:Class>
     
 

--- a/owl/EASE-STATE.owl
+++ b/owl/EASE-STATE.owl
@@ -11,6 +11,7 @@
      xmlns:EASE="http://www.ease-crc.org/ont/EASE.owl#">
     <owl:Ontology rdf:about="http://www.ease-crc.org/ont/EASE-STATE.owl">
         <owl:imports rdf:resource="package://ease_ontology/owl/EASE.owl"/>
+        <owl:imports rdf:resource="package://ease_ontology/owl/EASE-OBJ.owl"/>
     </owl:Ontology>
     
 
@@ -73,11 +74,33 @@
     
 
 
-    <!-- http://www.ease-crc.org/ont/EASE-STATE.owl#Accessor -->
+    <!-- http://www.ease-crc.org/ont/EASE-OBJ.owl#ConnectedObject -->
 
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-STATE.owl#Accessor">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-STATE.owl#UsuallyAgentive"/>
-    </owl:Class>
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-OBJ.owl#ConnectedObject"/>
+    
+
+
+    <!-- http://www.ease-crc.org/ont/EASE-OBJ.owl#Container -->
+
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-OBJ.owl#Container"/>
+    
+
+
+    <!-- http://www.ease-crc.org/ont/EASE-OBJ.owl#Item -->
+
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-OBJ.owl#Item"/>
+    
+
+
+    <!-- http://www.ease-crc.org/ont/EASE-OBJ.owl#Restrictor -->
+
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-OBJ.owl#Restrictor"/>
+    
+
+
+    <!-- http://www.ease-crc.org/ont/EASE-OBJ.owl#Supporter -->
+
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-OBJ.owl#Supporter"/>
     
 
 
@@ -103,7 +126,7 @@
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#definesRole"/>
-                <owl:someValuesFrom rdf:resource="http://www.ease-crc.org/ont/EASE-STATE.owl#ConnectedObject"/>
+                <owl:someValuesFrom rdf:resource="http://www.ease-crc.org/ont/EASE-OBJ.owl#ConnectedObject"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:comment>Describes a State in which some ConnectedObjects are placed in rigid contact, so that the movement of one determines the movement of others.</rdfs:comment>
@@ -124,14 +147,6 @@
         <rdfs:comment>A description of a State. This would include e.g. what acceptable regions for participant objects of the State might look like.
 
 Several other Description subclasses may function as Configurations. For example, a Goal is a description of a desired State. A Norm describes a State that should be maintained. A Diagnosis describes a State that causes certain symptoms etc.</rdfs:comment>
-    </owl:Class>
-    
-
-
-    <!-- http://www.ease-crc.org/ont/EASE-STATE.owl#ConnectedObject -->
-
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-STATE.owl#ConnectedObject">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-STATE.owl#UsuallyThematic"/>
     </owl:Class>
     
 
@@ -157,14 +172,6 @@ Several other Description subclasses may function as Configurations. For example
     
 
 
-    <!-- http://www.ease-crc.org/ont/EASE-STATE.owl#Container -->
-
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-STATE.owl#Container">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-STATE.owl#Restrictor"/>
-    </owl:Class>
-    
-
-
     <!-- http://www.ease-crc.org/ont/EASE-STATE.owl#Containment -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-STATE.owl#Containment">
@@ -181,7 +188,7 @@ Several other Description subclasses may function as Configurations. For example
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#definesRole"/>
-                <owl:someValuesFrom rdf:resource="http://www.ease-crc.org/ont/EASE-STATE.owl#Container"/>
+                <owl:someValuesFrom rdf:resource="http://www.ease-crc.org/ont/EASE-OBJ.owl#Container"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:comment>Describes a State in which an Item is placed inside a Container.</rdfs:comment>
@@ -207,13 +214,13 @@ Note that this State focuses on how the interaction of, usually non-agentive, ob
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#definesRole"/>
-                <owl:someValuesFrom rdf:resource="http://www.ease-crc.org/ont/EASE-STATE.owl#Item"/>
+                <owl:someValuesFrom rdf:resource="http://www.ease-crc.org/ont/EASE-OBJ.owl#Item"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#definesRole"/>
-                <owl:someValuesFrom rdf:resource="http://www.ease-crc.org/ont/EASE-STATE.owl#Restrictor"/>
+                <owl:someValuesFrom rdf:resource="http://www.ease-crc.org/ont/EASE-OBJ.owl#Restrictor"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:comment>Describes a state in which an Item and Restrictor are placed such that the Restrictor constrains the possible motions of the Item.</rdfs:comment>
@@ -241,14 +248,6 @@ Note that this State focuses on how the interaction of, usually non-agentive, ob
     
 
 
-    <!-- http://www.ease-crc.org/ont/EASE-STATE.owl#Item -->
-
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-STATE.owl#Item">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-STATE.owl#UsuallyThematic"/>
-    </owl:Class>
-    
-
-
     <!-- http://www.ease-crc.org/ont/EASE-STATE.owl#PhysicalAccessibility -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-STATE.owl#PhysicalAccessibility">
@@ -271,13 +270,13 @@ Note that this State focuses on how the interaction of, usually non-agentive, ob
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#definesRole"/>
-                <owl:someValuesFrom rdf:resource="http://www.ease-crc.org/ont/EASE-STATE.owl#Item"/>
+                <owl:someValuesFrom rdf:resource="http://www.ease-crc.org/ont/EASE-OBJ.owl#Item"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#definesRole"/>
-                <owl:someValuesFrom rdf:resource="http://www.ease-crc.org/ont/EASE-STATE.owl#Restrictor"/>
+                <owl:someValuesFrom rdf:resource="http://www.ease-crc.org/ont/EASE-OBJ.owl#Restrictor"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:comment>Describes a State in which an Item is located inside a Container or behind a Protector, but is still reachable for an Accessor so that the Accessor can perform some Task.
@@ -309,13 +308,13 @@ The Accessor and Task are optional in this description. If not explicitly specif
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#definesRole"/>
-                <owl:someValuesFrom rdf:resource="http://www.ease-crc.org/ont/EASE-STATE.owl#Item"/>
+                <owl:someValuesFrom rdf:resource="http://www.ease-crc.org/ont/EASE-OBJ.owl#Item"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#definesRole"/>
-                <owl:someValuesFrom rdf:resource="http://www.ease-crc.org/ont/EASE-STATE.owl#Restrictor"/>
+                <owl:someValuesFrom rdf:resource="http://www.ease-crc.org/ont/EASE-OBJ.owl#Restrictor"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:comment>Describes a State in which access to an Item is blocked by a Restrictor.</rdfs:comment>
@@ -323,18 +322,48 @@ The Accessor and Task are optional in this description. If not explicitly specif
     
 
 
-    <!-- http://www.ease-crc.org/ont/EASE-STATE.owl#Protector -->
+    <!-- http://www.ease-crc.org/ont/EASE-STATE.owl#PhysicalExistence -->
 
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-STATE.owl#Protector">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-STATE.owl#Restrictor"/>
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-STATE.owl#PhysicalExistence">
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-STATE.owl#PhysicalState"/>
+        <rdfs:comment>A State in which an Entity is said to exist in the physical world.</rdfs:comment>
     </owl:Class>
     
 
 
-    <!-- http://www.ease-crc.org/ont/EASE-STATE.owl#Restrictor -->
+    <!-- http://www.ease-crc.org/ont/EASE-STATE.owl#PhysicalState -->
 
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-STATE.owl#Restrictor">
-        <rdfs:subClassOf rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Role"/>
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-STATE.owl#PhysicalState">
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE.owl#State"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#hasParticipant"/>
+                <owl:someValuesFrom rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#PhysicalObject"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:comment>A State describing how Entities in the physical world relate to each other.</rdfs:comment>
+        <rdfs:label>Physical state</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://www.ease-crc.org/ont/EASE-STATE.owl#SocialState -->
+
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-STATE.owl#SocialState">
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE.owl#State"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#hasParticipant"/>
+                <owl:someValuesFrom rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Agent"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:comment>A State which describes how Agents relate to each other.
+
+One can argue that any Social state is a Physical state, since anything the Agents may use to construct a social relationship is made of physical things. The difference is that the physical support of the social relationships is not important here, what matters instead is the nature and content of the social relations, regardless of how they are physically realized.</rdfs:comment>
+        <rdfs:comment>Note here a distinction: the Agents involved must be able to communicate. This is because while it is often assumed that an Agent has or aspires to have similar cognitive capacities to a human, This need not be the case; in particular, not all Agents need to maintain theories of mind about each other and therefore not all Agents need to communicate with each other. It is hard to see what sort of meaning Social concepts might have to such Agents, since Social concepts are all about shared constructions.
+
+Note also that the DUL SocialAgent class is not an appropriate restriction however. SocialAgent is one that exists by agreement of PhysicalAgents. For example, a corporation or a nation are SocialAgents. An Agent with the capability to engage socially is not necessarily a DUL SocialAgent.</rdfs:comment>
+        <rdfs:label>Social state</rdfs:label>
     </owl:Class>
     
 
@@ -355,7 +384,7 @@ The Accessor and Task are optional in this description. If not explicitly specif
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#definesRole"/>
-                <owl:someValuesFrom rdf:resource="http://www.ease-crc.org/ont/EASE-STATE.owl#Supporter"/>
+                <owl:someValuesFrom rdf:resource="http://www.ease-crc.org/ont/EASE-OBJ.owl#Supporter"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:comment>Describes a state in which an Item cannot move under gravity because of its position relative to a Supporter.</rdfs:comment>
@@ -363,41 +392,15 @@ The Accessor and Task are optional in this description. If not explicitly specif
     
 
 
-    <!-- http://www.ease-crc.org/ont/EASE-STATE.owl#Supporter -->
-
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-STATE.owl#Supporter">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-STATE.owl#Restrictor"/>
-    </owl:Class>
-    
-
-
-    <!-- http://www.ease-crc.org/ont/EASE-STATE.owl#UsuallyAgentive -->
-
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-STATE.owl#UsuallyAgentive">
-        <rdfs:subClassOf rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Role"/>
-        <rdfs:comment>TODO: rename.
-
-Some roles to be used by State descriptions (Configurations) have an &quot;agentive&quot; flavor. However, the roles may be applied non-agentively as well. An example is an Accessor. Usually, it is an Agent that wishes to gain access, but we may speak of blockage when we want to prevent the wind to enter a room as well.</rdfs:comment>
-    </owl:Class>
-    
-
-
-    <!-- http://www.ease-crc.org/ont/EASE-STATE.owl#UsuallyThematic -->
-
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-STATE.owl#UsuallyThematic">
-        <rdfs:subClassOf rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Role"/>
-        <rdfs:comment>TODO: rename. Current name inspired by Theme/patient roles from linguistics.
-
-Some of the roles in State descriptions (Configurations) have a &quot;thematic&quot; flavor, that is, they are meant to classify objects that simply participate, rather than teleologically direct, events. Such roles may be applied to Agents however as well, sometimes; it&apos;s just that when applied to an Agent, it means that for this particular description we do not care about the agentive aspect of the entity.
-
-For example, consider a scenario where Bob leans against the wall. There is a contact state between Bob and the wall, but to describe it we do not need to make reference to Bob being an agent.</rdfs:comment>
-    </owl:Class>
-    
-
-
     <!-- http://www.ease-crc.org/ont/EASE.owl#State -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE.owl#State"/>
+    
+
+
+    <!-- http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Agent -->
+
+    <owl:Class rdf:about="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Agent"/>
     
 
 

--- a/owl/EASE.owl
+++ b/owl/EASE.owl
@@ -254,24 +254,6 @@ Sub-properties are used to distinct between different cases of event endpoint re
     
 
 
-    <!-- http://www.ease-crc.org/ont/EASE.owl#hasCreated -->
-
-    <owl:ObjectProperty rdf:about="http://www.ease-crc.org/ont/EASE.owl#hasCreated">
-        <rdfs:subPropertyOf rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#isParticipantIn"/>
-        <rdfs:label>has created</rdfs:label>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://www.ease-crc.org/ont/EASE.owl#hasDestroyed -->
-
-    <owl:ObjectProperty rdf:about="http://www.ease-crc.org/ont/EASE.owl#hasDestroyed">
-        <rdfs:subPropertyOf rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#isParticipantIn"/>
-        <rdfs:label>has destroyed</rdfs:label>
-    </owl:ObjectProperty>
-    
-
-
     <!-- http://www.ease-crc.org/ont/EASE.owl#hasGoal -->
 
     <owl:ObjectProperty rdf:about="http://www.ease-crc.org/ont/EASE.owl#hasGoal">
@@ -1073,31 +1055,6 @@ Such an event does NOT fall under the definition of Accident here. An example of
     
 
 
-    <!-- http://www.ease-crc.org/ont/EASE.owl#PhysicalExistence -->
-
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE.owl#PhysicalExistence">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE.owl#PhysicalState"/>
-        <rdfs:comment>A State in which an Entity is said to exist in the physical world.</rdfs:comment>
-    </owl:Class>
-    
-
-
-    <!-- http://www.ease-crc.org/ont/EASE.owl#PhysicalState -->
-
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE.owl#PhysicalState">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE.owl#State"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#hasParticipant"/>
-                <owl:someValuesFrom rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#PhysicalObject"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:comment>A State describing how Entities in the physical world relate to each other.</rdfs:comment>
-        <rdfs:label>Physical state</rdfs:label>
-    </owl:Class>
-    
-
-
     <!-- http://www.ease-crc.org/ont/EASE.owl#Question -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE.owl#Question">
@@ -1127,27 +1084,6 @@ Such an event does NOT fall under the definition of Accident here. An example of
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE.owl#Sluggishness">
         <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE.owl#Amateurish"/>
         <rdfs:comment>A description of sluggish behavior.</rdfs:comment>
-    </owl:Class>
-    
-
-
-    <!-- http://www.ease-crc.org/ont/EASE.owl#SocialState -->
-
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE.owl#SocialState">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE.owl#State"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#hasParticipant"/>
-                <owl:someValuesFrom rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Agent"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:comment>A State which describes how Agents relate to each other.
-
-One can argue that any Social state is a Physical state, since anything the Agents may use to construct a social relationship is made of physical things. The difference is that the physical support of the social relationships is not important here, what matters instead is the nature and content of the social relations, regardless of how they are physically realized.</rdfs:comment>
-        <rdfs:comment>Note here a distinction: the Agents involved must be able to communicate. This is because while it is often assumed that an Agent has or aspires to have similar cognitive capacities to a human, This need not be the case; in particular, not all Agents need to maintain theories of mind about each other and therefore not all Agents need to communicate with each other. It is hard to see what sort of meaning Social concepts might have to such Agents, since Social concepts are all about shared constructions.
-
-Note also that the DUL SocialAgent class is not an appropriate restriction however. SocialAgent is one that exists by agreement of PhysicalAgents. For example, a corporation or a nation are SocialAgents. An Agent with the capability to engage socially is not necessarily a DUL SocialAgent.</rdfs:comment>
-        <rdfs:label>Social state</rdfs:label>
     </owl:Class>
     
 


### PR DESCRIPTION
- moved state concepts from EASE.owl to EASE-STATE.owl
- moved roles from EASE-STATE.owl to EASE-OBJ.owl and aligned a bit (I have removed the concepts *UsuallyAgentive* & *UsuallyThematic* as they seem to not fit well with the current role taxonomy in EASE-OBJ
- I removed for now invalid properties *hasCreated* and *hasDestroyed*, sorry that this is part of this pull request but it allowed me to do a cherry-pick. Let's re-add them in another pull request.