### PR TITLE
Assembly -> Linkage refactoring

### DIFF
--- a/owl/EASE-OBJ.owl
+++ b/owl/EASE-OBJ.owl
@@ -445,6 +445,20 @@
     
 
 
+    <!-- http://www.ease-crc.org/ont/EASE-OBJ.owl#isLinkedTo -->
+
+    <owl:ObjectProperty rdf:about="http://www.ease-crc.org/ont/EASE-OBJ.owl#isLinkedTo">
+        <rdfs:subPropertyOf rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#hasLocation"/>
+        <owl:inverseOf rdf:resource="http://www.ease-crc.org/ont/EASE-OBJ.owl#isLinkedTo"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
+        <rdfs:domain rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#PhysicalObject"/>
+        <rdfs:range rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#PhysicalObject"/>
+        <rdfs:comment>A spatial relation holding between objects that are linked with each other such that they resist spatial separation.</rdfs:comment>
+        <rdfs:label>is linked to</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
     <!-- http://www.ease-crc.org/ont/EASE-OBJ.owl#isLocalizationOf -->
 
     <owl:ObjectProperty rdf:about="http://www.ease-crc.org/ont/EASE-OBJ.owl#isLocalizationOf">

--- a/owl/EASE-STATE.owl
+++ b/owl/EASE-STATE.owl
@@ -81,21 +81,6 @@
     
 
 
-    <!-- http://www.ease-crc.org/ont/EASE-STATE.owl#AssemblyConnection -->
-
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-STATE.owl#AssemblyConnection">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-STATE.owl#ContactGestallt"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#isDescribedBy"/>
-                <owl:someValuesFrom rdf:resource="http://www.ease-crc.org/ont/EASE-STATE.owl#AssemblyConnectionConfiguration"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:comment>Classifies States in which two objects are in a rigid connection, such that the movement of one determines the movement of the other.</rdfs:comment>
-    </owl:Class>
-    
-
-
     <!-- http://www.ease-crc.org/ont/EASE-STATE.owl#AssemblyConnectionConfiguration -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-STATE.owl#AssemblyConnectionConfiguration">
@@ -245,6 +230,21 @@ Note that this State focuses on how the interaction of, usually non-agentive, ob
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-STATE.owl#Item">
         <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-STATE.owl#UsuallyThematic"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.ease-crc.org/ont/EASE-STATE.owl#LinkageGestallt -->
+
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-STATE.owl#LinkageGestallt">
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-STATE.owl#ContactGestallt"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#isDescribedBy"/>
+                <owl:someValuesFrom rdf:resource="http://www.ease-crc.org/ont/EASE-STATE.owl#AssemblyConnectionConfiguration"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:comment>Classifies States in which two objects are in a rigid connection, such that the movement of one determines the movement of the other.</rdfs:comment>
     </owl:Class>
     
 

--- a/owl/EASE-STATE.owl
+++ b/owl/EASE-STATE.owl
@@ -235,6 +235,12 @@ Note that this State focuses on how the interaction of, usually non-agentive, ob
                 <owl:someValuesFrom rdf:resource="http://www.ease-crc.org/ont/EASE-OBJ.owl#LinkedObject"/>
             </owl:Restriction>
         </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#describes"/>
+                <owl:someValuesFrom rdf:resource="http://www.ease-crc.org/ont/EASE-STATE.owl#LinkageGestallt"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:comment>Describes a State in which some LinkedObjects are placed in rigid contact, so that the movement of one determines the movement of others.</rdfs:comment>
     </owl:Class>
     

--- a/owl/EASE-STATE.owl
+++ b/owl/EASE-STATE.owl
@@ -81,21 +81,6 @@
     
 
 
-    <!-- http://www.ease-crc.org/ont/EASE-STATE.owl#AssemblyConnectionConfiguration -->
-
-    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-STATE.owl#AssemblyConnectionConfiguration">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-STATE.owl#Configuration"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#definesRole"/>
-                <owl:someValuesFrom rdf:resource="http://www.ease-crc.org/ont/EASE-STATE.owl#ConnectedObject"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:comment>Describes a State in which some ConnectedObjects are placed in rigid contact, so that the movement of one determines the movement of others.</rdfs:comment>
-    </owl:Class>
-    
-
-
     <!-- http://www.ease-crc.org/ont/EASE-STATE.owl#Configuration -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-STATE.owl#Configuration">
@@ -234,6 +219,21 @@ Note that this State focuses on how the interaction of, usually non-agentive, ob
     
 
 
+    <!-- http://www.ease-crc.org/ont/EASE-STATE.owl#LinkageConfiguration -->
+
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-STATE.owl#LinkageConfiguration">
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-STATE.owl#Configuration"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#definesRole"/>
+                <owl:someValuesFrom rdf:resource="http://www.ease-crc.org/ont/EASE-STATE.owl#ConnectedObject"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:comment>Describes a State in which some ConnectedObjects are placed in rigid contact, so that the movement of one determines the movement of others.</rdfs:comment>
+    </owl:Class>
+    
+
+
     <!-- http://www.ease-crc.org/ont/EASE-STATE.owl#LinkageGestallt -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-STATE.owl#LinkageGestallt">
@@ -241,7 +241,7 @@ Note that this State focuses on how the interaction of, usually non-agentive, ob
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#isDescribedBy"/>
-                <owl:someValuesFrom rdf:resource="http://www.ease-crc.org/ont/EASE-STATE.owl#AssemblyConnectionConfiguration"/>
+                <owl:someValuesFrom rdf:resource="http://www.ease-crc.org/ont/EASE-STATE.owl#LinkageConfiguration"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:comment>Classifies States in which two objects are in a rigid connection, such that the movement of one determines the movement of the other.</rdfs:comment>

--- a/owl/EASE-STATE.owl
+++ b/owl/EASE-STATE.owl
@@ -249,7 +249,7 @@ Note that this State focuses on how the interaction of, usually non-agentive, ob
     <!-- http://www.ease-crc.org/ont/EASE-STATE.owl#LinkageGestallt -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-STATE.owl#LinkageGestallt">
-        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-STATE.owl#ContactGestallt"/>
+        <rdfs:subClassOf rdf:resource="http://www.ease-crc.org/ont/EASE-STATE.owl#Gestallt"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#isDescribedBy"/>

--- a/owl/EASE-STATE.owl
+++ b/owl/EASE-STATE.owl
@@ -73,6 +73,12 @@
     
 
 
+    <!-- http://www.ease-crc.org/ont/EASE-OBJ.owl#LinkedObject -->
+
+    <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-OBJ.owl#LinkedObject"/>
+    
+
+
     <!-- http://www.ease-crc.org/ont/EASE-STATE.owl#Accessor -->
 
     <owl:Class rdf:about="http://www.ease-crc.org/ont/EASE-STATE.owl#Accessor">
@@ -226,7 +232,7 @@ Note that this State focuses on how the interaction of, usually non-agentive, ob
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#definesRole"/>
-                <owl:someValuesFrom rdf:resource="http://www.ease-crc.org/ont/EASE-STATE.owl#ConnectedObject"/>
+                <owl:someValuesFrom rdf:resource="http://www.ease-crc.org/ont/EASE-OBJ.owl#LinkedObject"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:comment>Describes a State in which some ConnectedObjects are placed in rigid contact, so that the movement of one determines the movement of others.</rdfs:comment>

--- a/owl/EASE-STATE.owl
+++ b/owl/EASE-STATE.owl
@@ -235,7 +235,7 @@ Note that this State focuses on how the interaction of, usually non-agentive, ob
                 <owl:someValuesFrom rdf:resource="http://www.ease-crc.org/ont/EASE-OBJ.owl#LinkedObject"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <rdfs:comment>Describes a State in which some ConnectedObjects are placed in rigid contact, so that the movement of one determines the movement of others.</rdfs:comment>
+        <rdfs:comment>Describes a State in which some LinkedObjects are placed in rigid contact, so that the movement of one determines the movement of others.</rdfs:comment>
     </owl:Class>
     
 


### PR DESCRIPTION
Refactoring of *AssemblyConnection* and *AssemblyConnectionConfiguration*.

- I would prefer to use *Linkage* over *Assembly* to match the disposition model
- I think *LinkageGestallt* should probably not be a sub-concept of *ContactGestallt*. Thinking on relations they imply (i.e. *isLinkedTo* and *isInContactWith*), I would not see *isLinkedTo* as a sub-property of *isInContactWith*.
- In addition, the pull request adds property *isLinkedTo* in EASE-OBJ