### PR TITLE
Asserting array_* to be equivalent to xsd:string.

### DIFF
--- a/owl/EASE.owl
+++ b/owl/EASE.owl
@@ -81,37 +81,49 @@ A style recommendation for usage guidelines is that they should be brief. In con
 
     <!-- http://www.ease-crc.org/ont/EASE.owl#array_boolean -->
 
-    <rdfs:Datatype rdf:about="http://www.ease-crc.org/ont/EASE.owl#array_boolean"/>
+    <rdfs:Datatype rdf:about="http://www.ease-crc.org/ont/EASE.owl#array_boolean">
+        <owl:equivalentClass rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+    </rdfs:Datatype>
     
 
 
     <!-- http://www.ease-crc.org/ont/EASE.owl#array_double -->
 
-    <rdfs:Datatype rdf:about="http://www.ease-crc.org/ont/EASE.owl#array_double"/>
+    <rdfs:Datatype rdf:about="http://www.ease-crc.org/ont/EASE.owl#array_double">
+        <owl:equivalentClass rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+    </rdfs:Datatype>
     
 
 
     <!-- http://www.ease-crc.org/ont/EASE.owl#array_float -->
 
-    <rdfs:Datatype rdf:about="http://www.ease-crc.org/ont/EASE.owl#array_float"/>
+    <rdfs:Datatype rdf:about="http://www.ease-crc.org/ont/EASE.owl#array_float">
+        <owl:equivalentClass rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+    </rdfs:Datatype>
     
 
 
     <!-- http://www.ease-crc.org/ont/EASE.owl#array_int -->
 
-    <rdfs:Datatype rdf:about="http://www.ease-crc.org/ont/EASE.owl#array_int"/>
+    <rdfs:Datatype rdf:about="http://www.ease-crc.org/ont/EASE.owl#array_int">
+        <owl:equivalentClass rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+    </rdfs:Datatype>
     
 
 
     <!-- http://www.ease-crc.org/ont/EASE.owl#array_string -->
 
-    <rdfs:Datatype rdf:about="http://www.ease-crc.org/ont/EASE.owl#array_string"/>
+    <rdfs:Datatype rdf:about="http://www.ease-crc.org/ont/EASE.owl#array_string">
+        <owl:equivalentClass rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+    </rdfs:Datatype>
     
 
 
     <!-- http://www.ease-crc.org/ont/EASE.owl#array_uint -->
 
-    <rdfs:Datatype rdf:about="http://www.ease-crc.org/ont/EASE.owl#array_uint"/>
+    <rdfs:Datatype rdf:about="http://www.ease-crc.org/ont/EASE.owl#array_uint">
+        <owl:equivalentClass rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+    </rdfs:Datatype>
     
 
 


### PR DESCRIPTION
This PR sets all array_types to be equivalent to xsd:string. 

Resolves #57.